### PR TITLE
fix(repository): Use getCommits with options for fetching commits

### DIFF
--- a/backend/controllers/RepositoryController.js
+++ b/backend/controllers/RepositoryController.js
@@ -143,7 +143,10 @@ class RepositoryController {
       
       let commits;
       try {
-        commits = await githubService.getRepositoryCommits(owner, repo, targetCommitCount);
+        commits = await githubService.getCommits(owner, repo, { 
+          per_page: targetCommitCount,
+          includeStats: includeStats 
+        });
         console.log(`✅ Successfully fetched ${commits.length} commits for ${owner}/${repo}`);
       } catch (error) {
         console.error(`❌ Error fetching commits for ${owner}/${repo}:`, error.message);


### PR DESCRIPTION
  Updates the repository controller to use the getCommits method from the GitHub service, passing per_page and includeStats as options.

  This aligns the controller with the updated service method, ensuring that commit statistics are correctly included in the fetch
  request.